### PR TITLE
Update URL references

### DIFF
--- a/2004/CVE-2004-1235/README.md
+++ b/2004/CVE-2004-1235/README.md
@@ -3,7 +3,7 @@
 CVE-2004-1235
 
 Vulnerability reference:
- * [CVE-2004-1235](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2004-1235)  
+ * [CVE-2004-1235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2004-1235)  
  * [exp-db](https://www.exploit-db.com/exploits/744/)  
 
 ## Kernels

--- a/2005/CVE-2005-0736/README.md
+++ b/2005/CVE-2005-0736/README.md
@@ -3,7 +3,7 @@
 CVE-2005-0736
 
 Vulnerability reference:
- * [CVE-2005-0736](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2005-0736)  
+ * [CVE-2005-0736](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2005-0736)  
  * [exp-db](https://www.exploit-db.com/exploits/1397/)  
  
 ## Kernels

--- a/2005/CVE-2005-1263/README.md
+++ b/2005/CVE-2005-1263/README.md
@@ -8,7 +8,7 @@ leading to a buffer overflow.
 ```
 
 Vulnerability reference:
- * [CVE-2005-1263](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-1263)  
+ * [CVE-2005-1263](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-1263)  
  * [exp-db](https://www.exploit-db.com/exploits/25647/)  
 
 ## Kernels

--- a/2006/CVE-2006-2451/README.md
+++ b/2006/CVE-2006-2451/README.md
@@ -3,7 +3,7 @@
 CVE-2006-2451
 
 Vulnerability reference:
- * [CVE-2006-2451](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2006-2451)  
+ * [CVE-2006-2451](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2006-2451)  
  * [exp-db](http://www.exploit-db.com/exploits/2031/)  
 
 ## Kernels

--- a/2006/CVE-2006-3626/README.md
+++ b/2006/CVE-2006-3626/README.md
@@ -3,7 +3,7 @@
 CVE-2006-3626
 
 Vulnerability reference:
- * [CVE-2006-3626](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2006-3626)  
+ * [CVE-2006-3626](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2006-3626)  
  * [exp-db](https://www.exploit-db.com/exploits/2013/)  
 
 ## Kernels

--- a/2008/CVE-2008-0600/README.md
+++ b/2008/CVE-2008-0600/README.md
@@ -3,7 +3,7 @@
 CVE-2008-0600
 
 Vulnerability reference:
- * [CVE-2008-0600](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2008-0600)  
+ * [CVE-2008-0600](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2008-0600)  
  * [exp-db](https://www.exploit-db.com/exploits/5093/)  
  
 ## Kernels

--- a/2008/CVE-2008-0900/README.md
+++ b/2008/CVE-2008-0900/README.md
@@ -3,7 +3,7 @@
 CVE-2008-0900
 
 Vulnerability reference:
- * [CVE-2008-0900](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2008-0900)  
+ * [CVE-2008-0900](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2008-0900)  
  * [exp-db](https://www.exploit-db.com/exploits/5092/)  
 
 ## Kernels

--- a/2008/CVE-2008-4210/README.md
+++ b/2008/CVE-2008-4210/README.md
@@ -3,7 +3,7 @@
 CVE-2008-4210
 
 Vulnerability reference:
- * [CVE-2008-4210](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2008-4210)  
+ * [CVE-2008-4210](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2008-4210)  
  * [exp-db](https://www.exploit-db.com/exploits/6851/)  
 
 ## Kernels

--- a/2009/CVE-2009-1185/README.md
+++ b/2009/CVE-2009-1185/README.md
@@ -3,7 +3,7 @@
 CVE-2009-1185
 
 Vulnerability reference:
- * [CVE-2009-1185](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2009-1185)  
+ * [CVE-2009-1185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-1185)  
  * [exp-db](https://www.exploit-db.com/exploits/8478/)  
 
 ## Kernels

--- a/2009/CVE-2009-1337/README.md
+++ b/2009/CVE-2009-1337/README.md
@@ -3,7 +3,7 @@
 CVE-2009-1337
 
 Vulnerability reference:
- * [CVE-2009-1337](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2009-1337)  
+ * [CVE-2009-1337](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-1337)  
  * [exp-db](https://www.exploit-db.com/exploits/8369/)  
 
 ## Kernels

--- a/2009/CVE-2009-2692/README.md
+++ b/2009/CVE-2009-2692/README.md
@@ -3,7 +3,7 @@
 CVE-2009-2692
 
 Vulnerability reference:
- * [CVE-2009-2692](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2009-2692)  
+ * [CVE-2009-2692](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-2692)  
  * [exp-db](https://www.exploit-db.com/exploits/9435/) 
  * [exp-db](https://www.exploit-db.com/exploits/9436/) 
 

--- a/2009/CVE-2009-2698/README.md
+++ b/2009/CVE-2009-2698/README.md
@@ -3,7 +3,7 @@
 CVE-2009-2698
 
 Vulnerability reference:
- * [CVE-2009-2698](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2009-2698)  
+ * [CVE-2009-2698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-2698)  
 
 ## Kernels
 ```

--- a/2009/CVE-2009-3547/README.md
+++ b/2009/CVE-2009-3547/README.md
@@ -3,7 +3,7 @@
 CVE-2009-3547
 
 Vulnerability reference:
- * [CVE-2009-3547](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2009-3547)  
+ * [CVE-2009-3547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-3547)  
 
 ## Kernels
 ```

--- a/2010/CVE-2010-0415/README.md
+++ b/2010/CVE-2010-0415/README.md
@@ -3,7 +3,7 @@
 CVE-2010-0415
 
 Vulnerability reference:
- * [CVE-2010-0415](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-0415)  
+ * [CVE-2010-0415](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-0415)  
 
 ## Kernels
 ```

--- a/2010/CVE-2010-1146/README.md
+++ b/2010/CVE-2010-1146/README.md
@@ -3,7 +3,7 @@
 CVE-2010-1146
 
 Vulnerability reference:
- * [CVE-2010-1146](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-1146)  
+ * [CVE-2010-1146](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-1146)  
  * [exp-db](https://www.exploit-db.com/exploits/12130/)  
 
 ## Kernels

--- a/2010/CVE-2010-2959/README.md
+++ b/2010/CVE-2010-2959/README.md
@@ -3,7 +3,7 @@
 CVE-2010-2959
 
 Vulnerability reference:
- * [CVE-2010-2959](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-2959)  
+ * [CVE-2010-2959](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-2959)  
  * [exp-db](http://www.exploit-db.com/exploits/14814/)  
 
 ## Kernels

--- a/2010/CVE-2010-3081/README.md
+++ b/2010/CVE-2010-3081/README.md
@@ -3,7 +3,7 @@
 CVE-2010-3081
 
 Vulnerability reference:
- * [CVE-2010-3081](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3081)  
+ * [CVE-2010-3081](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3081)  
  * [exp-db](https://www.exploit-db.com/exploits/15024/)  
 
 ## Kernels

--- a/2010/CVE-2010-3301/README.md
+++ b/2010/CVE-2010-3301/README.md
@@ -3,8 +3,8 @@
 CVE-2010-3301
 
 Vulnerability reference:
- * [CVE-2010-3301](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3301)  
- * [exp-db](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3301)  
+ * [CVE-2010-3301](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-3301)  
+ * [exp-db](https://www.exploit-db.com/exploits/15023)  
 
 ## Kernels
 ```

--- a/2010/CVE-2010-3437/README.md
+++ b/2010/CVE-2010-3437/README.md
@@ -3,7 +3,7 @@
 CVE-2010-3437
 
 Vulnerability reference:
- * [CVE-2010-3437](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3437)  
+ * [CVE-2010-3437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3437)  
  * [exp-db](https://www.exploit-db.com/exploits/15150/)  
 
 ## Kernels

--- a/2010/CVE-2010-3904/README.md
+++ b/2010/CVE-2010-3904/README.md
@@ -3,7 +3,7 @@
 CVE-2010-3904
 
 Vulnerability reference:
- * [CVE-2010-3904](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3904)  
+ * [CVE-2010-3904](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-3904)  
  * [exp-db](http://www.exploit-db.com/exploits/15285/)  
 
 ## Kernels

--- a/2010/CVE-2010-4073/README.md
+++ b/2010/CVE-2010-4073/README.md
@@ -3,7 +3,7 @@
 CVE-2010-4073
 
 Vulnerability reference:
- * [CVE-2010-4073](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4073)  
+ * [CVE-2010-4073](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4073)  
  * [exp-db](https://www.exploit-db.com/exploits/17787/)  
 
 ## Kernels

--- a/2010/CVE-2010-4258/README.md
+++ b/2010/CVE-2010-4258/README.md
@@ -3,7 +3,7 @@
 CVE-2010-4258
 
 Vulnerability reference:
- * [CVE-2010-4258](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4258)  
+ * [CVE-2010-4258](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4258)  
  * [exp-db](https://www.exploit-db.com/exploits/15704/)  
 
 ## Kernels

--- a/2010/CVE-2010-4347/README.md
+++ b/2010/CVE-2010-4347/README.md
@@ -3,7 +3,8 @@
 CVE-2010-4347
 
 Vulnerability reference:
- * [CVE-2010-4347](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4347)  
+ * [CVE-2010-4347](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-4347)  
+ * [exp-db](https://www.exploit-db.com/exploits/15774)  
 
 ## Kernels
 ```

--- a/2012/CVE-2012-0056/README.md
+++ b/2012/CVE-2012-0056/README.md
@@ -3,7 +3,7 @@
 CVE-2012-0056
 
 Vulnerability reference:
- * [CVE-2012-0056](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2012-0056)  
+ * [CVE-2012-0056](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2012-0056)  
  * [exp-db](http://www.exploit-db.com/exploits/18411/)  
 
 ## Kernels

--- a/2012/CVE-2012-3524/README.md
+++ b/2012/CVE-2012-3524/README.md
@@ -9,7 +9,7 @@ not in libdbus itself: "we do not support use of libdbus in setuid binaries that
 
 
 Vulnerability reference:
- * [CVE-2012-3524](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-3524)  
+ * [CVE-2012-3524](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-3524)  
  * [exp-db](https://www.exploit-db.com/exploits/21323/)  
 
 ## libdbus

--- a/2013/CVE-2013-0268/README.md
+++ b/2013/CVE-2013-0268/README.md
@@ -3,7 +3,7 @@
 CVE-2013-0268
 
 Vulnerability reference:
- * [CVE-2013-0268](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2013-0268)  
+ * [CVE-2013-0268](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2013-0268)  
  * [exp-db](https://www.exploit-db.com/exploits/27297/)  
 
 ## Kernels

--- a/2013/CVE-2013-2094/README.md
+++ b/2013/CVE-2013-2094/README.md
@@ -3,7 +3,7 @@
 CVE-2013-2094
 
 Vulnerability reference:
- * [CVE-2013-2094](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2013-2094)  
+ * [CVE-2013-2094](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2013-2094)  
 
 ## Kernels
 ```

--- a/2014/CVE-2014-0038/README.md
+++ b/2014/CVE-2014-0038/README.md
@@ -3,7 +3,7 @@
 CVE-2014-0038
 
 Vulnerability reference:
- * [CVE-2014-0038](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2014-0038)  
+ * [CVE-2014-0038](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2014-0038)  
  * [exp-db](https://www.exploit-db.com/exploits/31347/)  
  * [exp-db](https://www.exploit-db.com/exploits/31346/)  
 

--- a/2014/CVE-2014-0196/README.md
+++ b/2014/CVE-2014-0196/README.md
@@ -3,7 +3,7 @@
 CVE-2014-0196
 
 Vulnerability reference:
- * [CVE-2014-0196](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2014-0196)  
+ * [CVE-2014-0196](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2014-0196)  
  * [exp-db](https://www.exploit-db.com/exploits/33516/)
 ## Kernels
 ```

--- a/2014/CVE-2014-4014/README.md
+++ b/2014/CVE-2014-4014/README.md
@@ -7,7 +7,7 @@ as demonstrated by setting the setgid bit on a file with group ownership of root
 
 
 Vulnerability reference:
- * [CVE-2014-4014](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4014)  
+ * [CVE-2014-4014](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4014)  
  * [exp-db](https://www.exploit-db.com/exploits/33824/)  
 
 ## Kernels

--- a/2014/CVE-2014-4699/README.md
+++ b/2014/CVE-2014-4699/README.md
@@ -3,7 +3,7 @@
 CVE-2014-4699
 
 Vulnerability reference:
- * [CVE-2014-4699](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4699)  
+ * [CVE-2014-4699](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4699)  
  * [exp-db](https://www.exploit-db.com/exploits/34134/)  
 
 ## Kernels

--- a/2014/CVE-2014-5284/README.md
+++ b/2014/CVE-2014-5284/README.md
@@ -3,7 +3,7 @@
 CVE-2014-5284  
 
 Vulnerability reference:
- * [CVE-2014-5284](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5284)  
+ * [CVE-2014-5284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5284)  
  * [exp-db](https://www.exploit-db.com/exploits/35234/)  
 
 

--- a/2015/CVE-2015-7547/README.md
+++ b/2015/CVE-2015-7547/README.md
@@ -3,7 +3,7 @@
 CVE-2015-7547
 
 Vulnerability reference:
- * [CVE-2015-7547](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7547)  
+ * [CVE-2015-7547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7547)  
  * [exp-db](https://www.exploit-db.com/exploits/39454/)  
 
 ## Glibc

--- a/2016/CVE-2016-0728/README.md
+++ b/2016/CVE-2016-0728/README.md
@@ -3,7 +3,7 @@
 CVE-2016-0728
 
 Vulnerability reference:
- * [CVE-2016-0728](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2016-0728)  
+ * [CVE-2016-0728](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2016-0728)  
 
 ## Kernels
 ```

--- a/2016/CVE-2016-2384/README.md
+++ b/2016/CVE-2016-2384/README.md
@@ -1,7 +1,7 @@
 CVE-2016-2384
 =============
 
-- [CVE-2016-2384](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2384)
+- [CVE-2016-2384](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2384)
 
 This is a proof-of-concept exploit for the vulnerability in the usb-midi Linux kernel driver ([CVE-2016-2384](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2384)).
 Requires physical access to the machine.

--- a/2016/CVE-2016-5195/README.md
+++ b/2016/CVE-2016-5195/README.md
@@ -15,7 +15,7 @@ All code, images and documentation in this page and the website is in the public
 ```
 
 Vulnerability reference:
- * [CVE-2016-5195](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2016-5195)  
+ * [CVE-2016-5195](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2016-5195)  
  * [Table of PoCs](https://github.com/dirtycow/dirtycow.github.io/wiki/PoCs)  
  * [exp-db](https://www.exploit-db.com/exploits/40616/)  
 

--- a/2016/CVE-2016-9793/README.md
+++ b/2016/CVE-2016-9793/README.md
@@ -1,9 +1,9 @@
 CVE-2016-9793
 =============
 
-- [CVE-2016-9793](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9793)  
+- [CVE-2016-9793](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9793)  
 
-This is a proof-of-concept local root exploit for the vulnerability in the SO\_SNDBUFFORCE and SO\_RCVBUFFORCE socket options implementation [CVE-2016-9793](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9793).
+This is a proof-of-concept local root exploit for the vulnerability in the SO\_SNDBUFFORCE and SO\_RCVBUFFORCE socket options implementation [CVE-2016-9793](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9793).
 Requires CAP\_NET\_ADMIN capability.
 
 Timeline:

--- a/2017/CVE-2017-5123/README.md
+++ b/2017/CVE-2017-5123/README.md
@@ -3,7 +3,7 @@
 CVE-2017-5123
 
 Vulnerability reference:
- * [CVE-2017-5123](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5123)  
+ * [CVE-2017-5123](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5123)  
 
 ## Kernels
 ```

--- a/2017/CVE-2017-6074/README.md
+++ b/2017/CVE-2017-6074/README.md
@@ -1,9 +1,9 @@
 CVE-2017-6074
 =============
 
-- [CVE-2017-6074](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6074)  
+- [CVE-2017-6074](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6074)  
 
-This is a proof-of-concept local root exploit for the vulnerability in the DCCP protocol implementation [CVE-2017-6074](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2017-6074).
+This is a proof-of-concept local root exploit for the vulnerability in the DCCP protocol implementation [CVE-2017-6074](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-6074).
 Includes a semireliable SMEP/SMAP bypass (the kernel might crash shorty after the exploit succeds).
 
 Some details: http://www.openwall.com/lists/oss-security/2017/02/26/2

--- a/2017/CVE-2017-7308/README.md
+++ b/2017/CVE-2017-7308/README.md
@@ -1,8 +1,8 @@
 CVE-2017-7308
 =============
 
-- [CVE-2017-7308](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7308)
+- [CVE-2017-7308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7308)
 
-This is a proof-of-concept local root exploit for the vulnerability in the AF\_PACKET sockets implementation [CVE-2017-7308](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2017-6074).
+This is a proof-of-concept local root exploit for the vulnerability in the AF\_PACKET sockets implementation [CVE-2017-7308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-6074).
 
 Details are here: https://googleprojectzero.blogspot.com/2017/05/exploiting-linux-kernel-via-packet.html

--- a/2017/CVE-2017-7494/README.md
+++ b/2017/CVE-2017-7494/README.md
@@ -3,7 +3,7 @@
 CVE-2017-7494
 
 Vulnerability reference:
- * [CVE-2016-0728](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2017-7494)  
+ * [CVE-2016-0728](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-7494)  
  * [exp-db](https://www.exploit-db.com/exploits/42060/)  
 
 ## Samba


### PR DESCRIPTION
This PR repairs a lot of the URLs in the older reference README files. Some of them reference the old cve.mitre.org site and the links no longer worked.